### PR TITLE
add doctest to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is an example repository for writing tests, for the Sciware Testing session
 
 - [`cmake`](https://cmake.org/download/)
 - C++ compiler with C++11 support (or higher)
+- [doctest](https://github.com/onqtam/doctest)
 
 ### Build
 ```bash


### PR DESCRIPTION
I didn't have doctest installed, nor do we have it on the cluster.  Is there an easy generic way we can tell people to install it? Would it make sense to just add doctest.h to the repo?